### PR TITLE
Provides access to a curve's control points

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,8 @@
       if (aX === 1) return 1;
       return calcBezier(getTForX(aX), mY1, mY2);
     };
+
+    f.getControlPoints = function() { return [{ x: mX1, y: mY1 }, { x: mX2, y: mY2 }]; };
     var str = "BezierEasing("+[mX1, mY1, mX2, mY2]+")";
     f.toString = function () { return str; };
 

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,20 @@ describe('BezierEasing', function(){
   it('should returns a function', function(){
     assert.ok(typeof BezierEasing(0, 0, 1, 1) === "function");
   });
+  describe('instance method: toString', function() {
+    it('should return "BezierEasing(args)"', function() {
+      assert.equal(BezierEasing(0, 0, 1, 1).toString(), "BezierEasing(0,0,1,1)");
+    });
+  });
+  describe('instance method: getControlPoints', function() {
+    it('should return the curve\'s control points', function() {
+      var pts = BezierEasing(0, 0, 1, 1).getControlPoints();
+      assert.equal(pts[0].x, 0, "first control point x should be 0");
+      assert.equal(pts[0].y, 0, "first control point y should be 0");
+      assert.equal(pts[1].x, 1, "second control point x should be 1");
+      assert.equal(pts[1].y, 1, "second control point y should be 1");
+    });
+  });
   it('should fail with wrong arguments', function () {
     assert.throws(function () { BezierEasing(); });
     assert.throws(function () { BezierEasing(1); });


### PR DESCRIPTION
I've added a `getControlPoints` instance method which generates and returns `[{x,y}, {x,y}]` for the curve. I like getting the points rather than a flat array of arguments as it's more semantic; I'm generating it each time to prevent the developer from editing it and thinking it'll have an effect. I'm assuming that it won't be called often enough to matter that it's generating new each time.

Adds tests for getControlPoints and toString.

Thoughts?
