### PR TITLE
Added AMD to the supported bower module types.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
   "description": "Bezier Curve based easing functions for Javascript animations",
   "moduleType": [
     "globals",
-    "node"
+    "node",
+    "amd"
   ],
   "keywords": [
     "cubic-bezier",


### PR DESCRIPTION
Since bezier-easing supports AMD, the bower.json file should indicate that. This fixes auto-generating a require.js config with bower-requirejs.
