### PR TITLE
Fix "Error: Mismatched anonymous define() module" when using r.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,8 @@
 (function (definition) {
   if (typeof exports === "object") {
     module.exports = definition();
-  }
-  else if (typeof window.define === 'function' && window.define.amd) {
-    window.define([], definition);
+  } else if (typeof define === 'function' && define.amd) {
+    define([], definition);
   } else {
     window.BezierEasing = definition();
   }


### PR DESCRIPTION
Using the r.js optimizer throws an "Error: Mismatched anonymous define() module" error if `window` is included in the define call. Removing it fixes the problem
