### PR TITLE
changes for incoming 1.0.0

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,22 @@
+{
+    "globals": {
+      "window": true,
+      "document": true
+    },
+    "indent": 2,
+    "node": true,
+    "bitwise": true,
+    "camelcase": false,
+    "eqeqeq": true,
+    "immed": true,
+    "latedef": true,
+    "undef": true,
+    "unused": true,
+    "trailing": true,
+    "smarttabs": false,
+    "forin": false,
+    "browser": false,
+    "globalstrict": false,
+    "esnext": false,
+    "quotmark": false
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 bezier-easing [![Build Status](https://travis-ci.org/gre/bezier-easing.png)](https://travis-ci.org/gre/bezier-easing)
 ===
 
-BezierEasing provides interpolation to make Bezier Curve based easing functions for your JavaScript animations.
+BezierEasing provides **Cubic Bezier** Curve easing which generalizes easing functions (ease-in, ease-out, ease-in-out, ...any other custom curve) exactly like in CSS Transitions.
+
+Implementing efficient lookup is not easy because it implies projecting
+the X coordinate to a Bezier Curve.
+This micro library uses fast heuristics (involving dichotomic search, newton-raphson, sampling) to focus on **performance** and **precision**.
+
+> It is heavily based on implementations available in Firefox and Chrome (for the CSS transition-timing-function property).
 
 Usage
 -------
@@ -27,7 +33,7 @@ It is the equivalent to [CSS Transitions' `transition-timing-function`](http://w
 
 
 In the same way you can define in CSS `cubic-bezier(0.42, 0, 0.58, 1)`,
-with BezierEasing, you can define it using `BezierEasing(0.42, 0, 0.58, 1)` which retuns a function taking an X and computing the Y interpolated easing value (see schema).
+with BezierEasing, you can define it using `BezierEasing(0.42, 0, 0.58, 1)` which have the `.get` function taking an X and computing the Y interpolated easing value (see schema).
 
 
 Example:
@@ -42,13 +48,15 @@ Predefined BezierEasing functions
 
 ```javscript
 BezierEasing.css = {
-  "ease":        BezierEasing(0.25, 0.1, 0.25, 1.0),
-  "linear":      BezierEasing(0.00, 0.0, 1.00, 1.0),
-  "ease-in":     BezierEasing(0.42, 0.0, 1.00, 1.0),
-  "ease-out":    BezierEasing(0.00, 0.0, 0.58, 1.0),
-  "ease-in-out": BezierEasing(0.42, 0.0, 0.58, 1.0)
+  "ease":        BezierEasing.ease = BezierEasing(0.25, 0.1, 0.25, 1.0),
+  "linear":      BezierEasing.linear = BezierEasing(0.00, 0.0, 1.00, 1.0),
+  "ease-in":     BezierEasing.easeIn = BezierEasing(0.42, 0.0, 1.00, 1.0),
+  "ease-out":    BezierEasing.easeOut = BezierEasing(0.00, 0.0, 0.58, 1.0),
+  "ease-in-out": BezierEasing.easeInOut = BezierEasing(0.42, 0.0, 0.58, 1.0)
 };
 ```
+
+There is also a `toCSS()` method that returns the transition-timing-function value string (so the library is agnostic).
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Usage
 ```javascript
 var easing = BezierEasing(0, 0, 1, 0.5);
 // easing is a function which projects x in [0.0, 1.0] onto the bezier-curve defined by the 4 points (see schema below).
-console.log(easing(0.0)); // 0.0
-console.log(easing(0.5)); // 0.3125
-console.log(easing(1.0)); // 1.0
+console.log(easing.get(0.0)); // 0.0
+console.log(easing.get(0.5)); // 0.3125
+console.log(easing.get(1.0)); // 1.0
 ```
 
 (this schema is from the CSS spec)

--- a/benchmark.js
+++ b/benchmark.js
@@ -5,18 +5,18 @@ var suite = new Benchmark.Suite();
 
 var random = Math.random;
 
-var bezier = BezierEasing(0.2, 0.3, 1.0, 0.5);
+var bezier = BezierEasing([ 0.2, 0.3, 1.0, 0.5 ]);
 
 suite
 .add('BezierEasing: instanciation', function() {
-  BezierEasing(random(), random(), random(), random());
+  BezierEasing([ random(), random(), random(), random() ]);
 })
 .add('BezierEasing: call', function() {
-  bezier(random());
+  bezier.get(random());
 })
 .add('BezierEasing: instanciation + call', function() {
-  var bezier = BezierEasing(random(), random(), random(), random());
-  bezier(random());
+  var bezier = BezierEasing([ random(), random(), random(), random() ]);
+  bezier.get(random());
 })
 // add listeners
 .on('cycle', function(event) {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@
  *
  */
 
-
 // These values are established by empiricism with tests (tradeoff: performance VS precision)
 var NEWTON_ITERATIONS = 4;
 var NEWTON_MIN_SLOPE = 0.001;
@@ -168,11 +167,11 @@ BezierEasing.prototype = {
 
 // CSS mapping
 BezierEasing.css = {
-  "ease":        BezierEasing([ 0.25, 0.1, 0.25, 1.0 ]),
-  "linear":      BezierEasing([ 0.00, 0.0, 1.00, 1.0 ]),
-  "ease-in":     BezierEasing([ 0.42, 0.0, 1.00, 1.0 ]),
-  "ease-out":    BezierEasing([ 0.00, 0.0, 0.58, 1.0 ]),
-  "ease-in-out": BezierEasing([ 0.42, 0.0, 0.58, 1.0 ])
+  "ease":        BezierEasing.ease      = BezierEasing(0.25, 0.1, 0.25, 1.0),
+  "linear":      BezierEasing.linear    = BezierEasing(0.00, 0.0, 1.00, 1.0),
+  "ease-in":     BezierEasing.easeIn    = BezierEasing(0.42, 0.0, 1.00, 1.0),
+  "ease-out":    BezierEasing.easeOut   = BezierEasing(0.00, 0.0, 0.58, 1.0),
+  "ease-in-out": BezierEasing.easeInOut = BezierEasing(0.42, 0.0, 0.58, 1.0)
 };
 
 module.exports = BezierEasing;

--- a/index.js
+++ b/index.js
@@ -1,156 +1,178 @@
 /**
  * BezierEasing - use bezier curve for transition easing function
- * by Gaëtan Renaudeau 2014 – MIT License
+ * by Gaëtan Renaudeau 2014 - 2015 – MIT License
  *
  * Credits: is based on Firefox's nsSMILKeySpline.cpp
  * Usage:
- * var spline = BezierEasing(0.25, 0.1, 0.25, 1.0)
- * spline(x) => returns the easing value | x must be in [0, 1] range
+ * var spline = BezierEasing([ 0.25, 0.1, 0.25, 1.0 ])
+ * spline.get(x) => returns the easing value | x must be in [0, 1] range
  *
  */
-(function (definition) {
-  if (typeof exports === "object") {
-    module.exports = definition();
-  } else if (typeof define === 'function' && define.amd) {
-    define([], definition);
-  } else {
-    window.BezierEasing = definition();
+
+
+// These values are established by empiricism with tests (tradeoff: performance VS precision)
+var NEWTON_ITERATIONS = 4;
+var NEWTON_MIN_SLOPE = 0.001;
+var SUBDIVISION_PRECISION = 0.0000001;
+var SUBDIVISION_MAX_ITERATIONS = 10;
+
+var kSplineTableSize = 11;
+var kSampleStepSize = 1.0 / (kSplineTableSize - 1.0);
+
+var float32ArraySupported = 'Float32Array' in global;
+
+function A (aA1, aA2) { return 1.0 - 3.0 * aA2 + 3.0 * aA1; }
+function B (aA1, aA2) { return 3.0 * aA2 - 6.0 * aA1; }
+function C (aA1)      { return 3.0 * aA1; }
+
+// Returns x(t) given t, x1, and x2, or y(t) given t, y1, and y2.
+function calcBezier (aT, aA1, aA2) {
+  return ((A(aA1, aA2)*aT + B(aA1, aA2))*aT + C(aA1))*aT;
+}
+
+// Returns dx/dt given t, x1, and x2, or dy/dt given t, y1, and y2.
+function getSlope (aT, aA1, aA2) {
+  return 3.0 * A(aA1, aA2)*aT*aT + 2.0 * B(aA1, aA2) * aT + C(aA1);
+}
+
+function binarySubdivide (aX, aA, aB, mX1, mX2) {
+  var currentX, currentT, i = 0;
+  do {
+    currentT = aA + (aB - aA) / 2.0;
+    currentX = calcBezier(currentT, mX1, mX2) - aX;
+    if (currentX > 0.0) {
+      aB = currentT;
+    } else {
+      aA = currentT;
+    }
+  } while (Math.abs(currentX) > SUBDIVISION_PRECISION && ++i < SUBDIVISION_MAX_ITERATIONS);
+  return currentT;
+}
+
+function newtonRaphsonIterate (aX, aGuessT, mX1, mX2) {
+  for (var i = 0; i < NEWTON_ITERATIONS; ++i) {
+    var currentSlope = getSlope(aGuessT, mX1, mX2);
+    if (currentSlope === 0.0) return aGuessT;
+    var currentX = calcBezier(aGuessT, mX1, mX2) - aX;
+    aGuessT -= currentX / currentSlope;
   }
-}(function () {
-  var global = this;
+  return aGuessT;
+}
 
-  // These values are established by empiricism with tests (tradeoff: performance VS precision)
-  var NEWTON_ITERATIONS = 4;
-  var NEWTON_MIN_SLOPE = 0.001;
-  var SUBDIVISION_PRECISION = 0.0000001;
-  var SUBDIVISION_MAX_ITERATIONS = 10;
-
-  var kSplineTableSize = 11;
-  var kSampleStepSize = 1.0 / (kSplineTableSize - 1.0);
-
-  var float32ArraySupported = 'Float32Array' in global;
-
-  function A (aA1, aA2) { return 1.0 - 3.0 * aA2 + 3.0 * aA1; }
-  function B (aA1, aA2) { return 3.0 * aA2 - 6.0 * aA1; }
-  function C (aA1)      { return 3.0 * aA1; }
-
-  // Returns x(t) given t, x1, and x2, or y(t) given t, y1, and y2.
-  function calcBezier (aT, aA1, aA2) {
-    return ((A(aA1, aA2)*aT + B(aA1, aA2))*aT + C(aA1))*aT;
+/**
+ * points is an array of [ mX1, mY1, mX2, mY2 ]
+ */
+function BezierEasing (points, b, c, d) {
+  if (arguments.length === 4) {
+    return new BezierEasing([ points, b, c, d ]);
   }
+  if (!(this instanceof BezierEasing)) return new BezierEasing(points);
 
-  // Returns dx/dt given t, x1, and x2, or dy/dt given t, y1, and y2.
-  function getSlope (aT, aA1, aA2) {
-    return 3.0 * A(aA1, aA2)*aT*aT + 2.0 * B(aA1, aA2) * aT + C(aA1);
+  if (!points || points.length !== 4) {
+    throw new Error("BezierEasing: points must contains 4 values");
   }
-
-  function binarySubdivide (aX, aA, aB, mX1, mX2) {
-    var currentX, currentT, i = 0;
-    do {
-      currentT = aA + (aB - aA) / 2.0;
-      currentX = calcBezier(currentT, mX1, mX2) - aX;
-      if (currentX > 0.0) {
-        aB = currentT;
-      } else {
-        aA = currentT;
-      }
-    } while (Math.abs(currentX) > SUBDIVISION_PRECISION && ++i < SUBDIVISION_MAX_ITERATIONS);
-    return currentT;
+  for (var i=0; i<4; ++i) {
+    if (typeof points[i] !== "number" || isNaN(points[i]) || !isFinite(points[i])) {
+      throw new Error("BezierEasing: points should be integers.");
+    }
   }
-
-  function BezierEasing (mX1, mY1, mX2, mY2) {
-    // Validate arguments
-    if (arguments.length !== 4) {
-      throw new Error("BezierEasing requires 4 arguments.");
-    }
-    for (var i=0; i<4; ++i) {
-      if (typeof arguments[i] !== "number" || isNaN(arguments[i]) || !isFinite(arguments[i])) {
-        throw new Error("BezierEasing arguments should be integers.");
-      }
-    }
-    if (mX1 < 0 || mX1 > 1 || mX2 < 0 || mX2 > 1) {
-      throw new Error("BezierEasing x values must be in [0, 1] range.");
-    }
-
-    var mSampleValues = float32ArraySupported ? new Float32Array(kSplineTableSize) : new Array(kSplineTableSize);
-
-    function newtonRaphsonIterate (aX, aGuessT) {
-      for (var i = 0; i < NEWTON_ITERATIONS; ++i) {
-        var currentSlope = getSlope(aGuessT, mX1, mX2);
-        if (currentSlope === 0.0) return aGuessT;
-        var currentX = calcBezier(aGuessT, mX1, mX2) - aX;
-        aGuessT -= currentX / currentSlope;
-      }
-      return aGuessT;
-    }
-
-    function calcSampleValues () {
-      for (var i = 0; i < kSplineTableSize; ++i) {
-        mSampleValues[i] = calcBezier(i * kSampleStepSize, mX1, mX2);
-      }
-    }
-
-    function getTForX (aX) {
-      var intervalStart = 0.0;
-      var currentSample = 1;
-      var lastSample = kSplineTableSize - 1;
-
-      for (; currentSample != lastSample && mSampleValues[currentSample] <= aX; ++currentSample) {
-        intervalStart += kSampleStepSize;
-      }
-      --currentSample;
-
-      // Interpolate to provide an initial guess for t
-      var dist = (aX - mSampleValues[currentSample]) / (mSampleValues[currentSample+1] - mSampleValues[currentSample]);
-      var guessForT = intervalStart + dist * kSampleStepSize;
-
-      var initialSlope = getSlope(guessForT, mX1, mX2);
-      if (initialSlope >= NEWTON_MIN_SLOPE) {
-        return newtonRaphsonIterate(aX, guessForT);
-      } else if (initialSlope === 0.0) {
-        return guessForT;
-      } else {
-        return binarySubdivide(aX, intervalStart, intervalStart + kSampleStepSize, mX1, mX2);
-      }
-    }
-
-    var _precomputed = false;
-    function precompute() {
-      _precomputed = true;
-      if (mX1 != mY1 || mX2 != mY2)
-        calcSampleValues();
-    }
-
-    var f = function (aX) {
-      if (!_precomputed) precompute();
-      if (mX1 === mY1 && mX2 === mY2) return aX; // linear
-      // Because JavaScript number are imprecise, we should guarantee the extremes are right.
-      if (aX === 0) return 0;
-      if (aX === 1) return 1;
-      return calcBezier(getTForX(aX), mY1, mY2);
-    };
-
-    f.getControlPoints = function() { return [{ x: mX1, y: mY1 }, { x: mX2, y: mY2 }]; };
-
-    var args = [mX1, mY1, mX2, mY2];
-    var str = "BezierEasing("+args+")";
-    f.toString = function () { return str; };
-
-    var css = "cubic-bezier("+args+")";
-    f.toCSS = function () { return css; };
-
-    return f;
+  if (points[0] < 0 || points[0] > 1 || points[2] < 0 || points[2] > 1) {
+    throw new Error("BezierEasing x values must be in [0, 1] range.");
   }
 
-  // CSS mapping
-  BezierEasing.css = {
-    "ease":        BezierEasing(0.25, 0.1, 0.25, 1.0),
-    "linear":      BezierEasing(0.00, 0.0, 1.00, 1.0),
-    "ease-in":     BezierEasing(0.42, 0.0, 1.00, 1.0),
-    "ease-out":    BezierEasing(0.00, 0.0, 0.58, 1.0),
-    "ease-in-out": BezierEasing(0.42, 0.0, 0.58, 1.0)
-  };
+  this._str = "BezierEasing("+points+")";
+  this._css = "cubic-bezier("+points+")";
+  this._p = points;
+  this._mSampleValues = float32ArraySupported ? new Float32Array(kSplineTableSize) : new Array(kSplineTableSize);
+  this._precomputed = false;
+}
 
-  return BezierEasing;
+BezierEasing.prototype = {
 
-}));
+  get: function (x) {
+    var mX1 = this._p[0],
+      mY1 = this._p[1],
+      mX2 = this._p[2],
+      mY2 = this._p[3];
+    if (!this._precomputed) this._precompute();
+    if (mX1 === mY1 && mX2 === mY2) return x; // linear
+    // Because JavaScript number are imprecise, we should guarantee the extremes are right.
+    if (x === 0) return 0;
+    if (x === 1) return 1;
+    return calcBezier(this._getTForX(x), mY1, mY2);
+  },
+
+  getPoints: function() {
+    return this._p;
+  },
+
+  toString: function () {
+    return this._str;
+  },
+
+  toCSS: function () {
+    return this._css;
+  },
+
+  // Private part
+
+  _precompute: function () {
+    var mX1 = this._p[0],
+      mY1 = this._p[1],
+      mX2 = this._p[2],
+      mY2 = this._p[3];
+    this._precomputed = true;
+    if (mX1 !== mY1 || mX2 !== mY2)
+      this._calcSampleValues();
+  },
+
+  _calcSampleValues: function () {
+    var mX1 = this._p[0],
+      mX2 = this._p[2];
+    for (var i = 0; i < kSplineTableSize; ++i) {
+      this._mSampleValues[i] = calcBezier(i * kSampleStepSize, mX1, mX2);
+    }
+  },
+
+  /**
+   * getTForX chose the fastest heuristic to determine the percentage value precisely from a given X projection.
+   */
+  _getTForX: function (aX) {
+    var mX1 = this._p[0],
+      mX2 = this._p[2],
+      mSampleValues = this._mSampleValues;
+
+    var intervalStart = 0.0;
+    var currentSample = 1;
+    var lastSample = kSplineTableSize - 1;
+
+    for (; currentSample !== lastSample && mSampleValues[currentSample] <= aX; ++currentSample) {
+      intervalStart += kSampleStepSize;
+    }
+    --currentSample;
+
+    // Interpolate to provide an initial guess for t
+    var dist = (aX - mSampleValues[currentSample]) / (mSampleValues[currentSample+1] - mSampleValues[currentSample]);
+    var guessForT = intervalStart + dist * kSampleStepSize;
+
+    var initialSlope = getSlope(guessForT, mX1, mX2);
+    if (initialSlope >= NEWTON_MIN_SLOPE) {
+      return newtonRaphsonIterate(aX, guessForT, mX1, mX2);
+    } else if (initialSlope === 0.0) {
+      return guessForT;
+    } else {
+      return binarySubdivide(aX, intervalStart, intervalStart + kSampleStepSize, mX1, mX2);
+    }
+  }
+};
+
+// CSS mapping
+BezierEasing.css = {
+  "ease":        BezierEasing([ 0.25, 0.1, 0.25, 1.0 ]),
+  "linear":      BezierEasing([ 0.00, 0.0, 1.00, 1.0 ]),
+  "ease-in":     BezierEasing([ 0.42, 0.0, 1.00, 1.0 ]),
+  "ease-out":    BezierEasing([ 0.00, 0.0, 0.58, 1.0 ]),
+  "ease-in-out": BezierEasing([ 0.42, 0.0, 0.58, 1.0 ])
+};
+
+module.exports = BezierEasing;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bezier-easing",
   "version": "0.4.5",
-  "description": "Bezier Curve based easing functions for Javascript animations",
+  "description": "BezierEasing provides Cubic Bezier Curve easing which generalizes easing functions exactly like in CSS Transitions.",
   "keywords": [
     "cubic-bezier",
     "bezier",

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,9 @@
 var BezierEasing = require("..");
 var assert = require("assert");
 
-function identity (x) { return x; }
+var identity = {
+  get: function (x) { return x; }
+};
 
 function assertClose (a, b, message, precision) {
   if (!precision) precision = 0.000001;
@@ -19,7 +21,7 @@ function allEquals (be1, be2, samples, assertion) {
   if (!assertion) assertion = assertClose;
   for (var i=0; i<=samples; ++i) {
     var x = i / samples;
-    assertion(be1(x), be2(x), "comparing "+be1+" and "+be2+" for value "+x);
+    assertion(be1.get(x), be2.get(x), "comparing "+be1+" and "+be2+" for value "+x);
   }
 }
 
@@ -33,12 +35,13 @@ describe('BezierEasing', function(){
   it('should be a function', function(){
     assert.ok(typeof BezierEasing === "function");
   });
-  it('should returns a function', function(){
-    assert.ok(typeof BezierEasing(0, 0, 1, 1) === "function");
+  it('should creates an object', function(){
+    assert.ok(typeof BezierEasing([ 0, 0, 1, 1 ]) === "object");
+    assert.ok(typeof (new BezierEasing([ 0, 0, 1, 1 ])) === "object");
   });
   describe('instance method: toString', function() {
     it('should return "BezierEasing(args)"', function() {
-      assert.equal(BezierEasing(0, 0, 1, 1).toString(), "BezierEasing(0,0,1,1)");
+      assert.equal(BezierEasing([ 0, 0, 1, 1 ]).toString(), "BezierEasing(0,0,1,1)");
     });
   });
   describe('instance method: toCSS', function () {
@@ -46,51 +49,55 @@ describe('BezierEasing', function(){
       assert.equal(BezierEasing(0, 0, 1, 1).toCSS(), "cubic-bezier(0,0,1,1)");
     });
   });
-  describe('instance method: getControlPoints', function() {
+  describe('instance method: getPoints', function() {
     it('should return the curve\'s control points', function() {
-      var pts = BezierEasing(0, 0, 1, 1).getControlPoints();
-      assert.equal(pts[0].x, 0, "first control point x should be 0");
-      assert.equal(pts[0].y, 0, "first control point y should be 0");
-      assert.equal(pts[1].x, 1, "second control point x should be 1");
-      assert.equal(pts[1].y, 1, "second control point y should be 1");
+      var pts = BezierEasing(0, 0.1, 0.9, 1).getPoints();
+      assert.equal(pts[0], 0, "first control point x should be 0");
+      assert.equal(pts[1], 0.1, "first control point y should be 0");
+      assert.equal(pts[2], 0.9, "second control point x should be 1");
+      assert.equal(pts[3], 1, "second control point y should be 1");
     });
   });
   it('should fail with wrong arguments', function () {
     assert.throws(function () { BezierEasing(); });
-    assert.throws(function () { BezierEasing(1); });
-    assert.throws(function () { BezierEasing(1, 0, 1); });
-    assert.throws(function () { BezierEasing(1, 0, 1, "a"); });
-    assert.throws(function () { BezierEasing(1, 0, 1, NaN); });
-    assert.throws(function () { BezierEasing(1, 0, 1, Infinity); });
-    assert.throws(function () { BezierEasing(0.5, 0.5, -5, 0.5); });
-    assert.throws(function () { BezierEasing(0.5, 0.5, 5, 0.5); });
-    assert.throws(function () { BezierEasing(-2, 0.5, 0.5, 0.5); });
-    assert.throws(function () { BezierEasing(2, 0.5, 0.5, 0.5); });
-    assert.throws(function () { BezierEasing(-Math.random()-0.000001, 0.5, 0.5, 0.5); });
-    assert.throws(function () { BezierEasing(0.5, 0.5, 1.000001+Math.random(), 0.5); });
+    assert.throws(function () { BezierEasing([1 ]); });
+    assert.throws(function () { BezierEasing([ 1 ], 1, 1, 1); });
+    assert.throws(function () { BezierEasing([ 1, 0, 1 ]); });
+    assert.throws(function () { BezierEasing([1, 0, 1, "a" ]); });
+    assert.throws(function () { BezierEasing([ 1, 0, 1, NaN ]); });
+    assert.throws(function () { BezierEasing([ 1, 0, 1, Infinity ]); });
+    assert.throws(function () { BezierEasing([ 0.5, 0.5, -5, 0.5 ]); });
+    assert.throws(function () { BezierEasing([ 0.5, 0.5, 5, 0.5 ]); });
+    assert.throws(function () { BezierEasing([ -2, 0.5, 0.5, 0.5 ]); });
+    assert.throws(function () { BezierEasing([ 2, 0.5, 0.5, 0.5 ]); });
+    assert.throws(function () { BezierEasing([ 2, 0.5, 0.5, 0.5 ], 1); });
+    assert.throws(function () { BezierEasing([ -Math.random()-0.000001, 0.5, 0.5, 0.5 ]); });
+    assert.throws(function () { BezierEasing([ 0.5, 0.5, 1.000001+Math.random(), 0.5 ]); });
   });
   describe('linear curves', function () {
     it('should be linear', function () {
-      allEquals(BezierEasing(0, 0, 1, 1), BezierEasing(1, 1, 0, 0), 100);
-      allEquals(BezierEasing(0, 0, 1, 1), identity, 100);
+      allEquals(BezierEasing([ 0, 0, 1, 1 ]), BezierEasing([ 1, 1, 0, 0 ]), 100);
+      allEquals(BezierEasing([ 0, 0, 1, 1 ]), identity, 100);
     });
   });
   describe('common properties', function () {
     it('should be the right value at extremes', function () {
       repeat(1000)(function () {
         var a = Math.random(), b = 2*Math.random()-0.5, c = Math.random(), d = 2*Math.random()-0.5;
-        var easing = BezierEasing(a, b, c, d);
-        assert.equal(easing(0), 0, easing+"(0) should be 0.");
-        assert.equal(easing(1), 1, easing+"(1) should be 1.");
+        var easing = BezierEasing([ a, b, c, d ]);
+        assert.equal(easing.get(0), 0, easing+"(0) should be 0.");
+        assert.equal(easing.get(1), 1, easing+"(1) should be 1.");
       });
     });
 
     it('should approach the projected value of its x=y projected curve', function () {
       repeat(1000)(function () {
         var a = Math.random(), b = Math.random(), c = Math.random(), d = Math.random();
-        var easing = BezierEasing(a, b, c, d);
-        var projected = BezierEasing(b, a, d, c);
-        var composed = function (x) { return projected(easing(x)); };
+        var easing = BezierEasing([ a, b, c, d ]);
+        var projected = BezierEasing([ b, a, d, c ]);
+        var composed = {
+          get: function (x) { return projected.get(easing.get(x)); }
+        };
         allEquals(identity, composed, 100, makeAssertCloseWithPrecision(0.05));
       });
     });
@@ -99,7 +106,7 @@ describe('BezierEasing', function(){
     it('should be strictly equals', function () {
       repeat(100)(function () {
         var a = Math.random(), b = 2*Math.random()-0.5, c = Math.random(), d = 2*Math.random()-0.5;
-        allEquals(BezierEasing(a, b, c, d), BezierEasing(a, b, c, d), 100, 0);
+        allEquals(BezierEasing([ a, b, c, d ]), BezierEasing([ a, b, c, d ]), 100, 0);
       });
     });
   });
@@ -107,15 +114,17 @@ describe('BezierEasing', function(){
     it('should have a central value y~=0.5 at x=0.5', function () {
       repeat(100)(function () {
         var a = Math.random(), b = 2*Math.random()-0.5, c = 1-a, d = 1-b;
-        var easing = BezierEasing(a, b, c, d);
-        assertClose(easing(0.5), 0.5, easing+"(0.5) should be 0.5");
+        var easing = BezierEasing([ a, b, c, d ]);
+        assertClose(easing.get(0.5), 0.5, easing+"(0.5) should be 0.5");
       });
     });
     it('should be symetrical', function () {
       repeat(100)(function () {
         var a = Math.random(), b = 2*Math.random()-0.5, c = 1-a, d = 1-b;
         var easing = BezierEasing(a, b, c, d);
-        var sym = function (x) { return 1 - easing(1-x); };
+        var sym = {
+          get: function (x) { return 1 - easing.get(1-x); }
+        };
         allEquals(easing, sym, 100);
       });
     });
@@ -124,7 +133,7 @@ describe('BezierEasing', function(){
       it('should have the 5 properties', function () {
         ["ease", "linear", "ease-in", "ease-out", "ease-in-out"].forEach(function (prop) {
           assert(prop in BezierEasing.css, "BezierEasing.css."+prop+" is defined.");
-          assert(typeof BezierEasing.css[prop] === "function", "BezierEasing.css."+prop+" is a function.");
+          assert(typeof BezierEasing.css[prop] === "object", "BezierEasing.css."+prop+" is an object.");
         });
       });
   });

--- a/visual-demo.js
+++ b/visual-demo.js
@@ -19,7 +19,7 @@ function create (n, w, lh, easing) {
   }
   return function (t) {
     for (var i=0; i<els.length; ++i) {
-      var percent = easing((1 + Math.cos((t + i * 200) / 1500)) / 2);
+      var percent = easing.get((1 + Math.cos((t + i * 200) / 1500)) / 2);
       els[i].style.transform = "translateX("+(percent * 100)+"%)";
     }
   };
@@ -29,12 +29,12 @@ var w = 200;
 var n = 100;
 var lh = 6;
 var renders = []
-.concat(create(n, w, lh, BezierEasing(0.2, 0.3, 1.0, 0.2)))
-.concat(create(n, w, lh, BezierEasing(0.1, 0.0, 1.0, 0.95)))
-.concat(create(n, w, lh, BezierEasing(0.2, 1.0, 1.0, 1.0)))
-.concat(create(n, w, lh, BezierEasing(0.8,0.5,0.0,0.8)))
-.concat(create(n, w, lh, BezierEasing(0.16,1,0.7,0.0)))
-.concat(create(n, w, lh, BezierEasing(0.03,0.9,0.2,0.46)));
+.concat(create(n, w, lh, BezierEasing([ 0.2, 0.3, 1.0, 0.2 ])))
+.concat(create(n, w, lh, BezierEasing([ 0.1, 0.0, 1.0, 0.95 ])))
+.concat(create(n, w, lh, BezierEasing([ 0.2, 1.0, 1.0, 1.0 ])))
+.concat(create(n, w, lh, BezierEasing([ 0.8,0.5,0.0,0.8 ])))
+.concat(create(n, w, lh, BezierEasing([ 0.16,1,0.7,0.0 ])))
+.concat(create(n, w, lh, BezierEasing([ 0.03,0.9,0.2,0.46 ])));
 
 requestAnimationFrame(function loop (t) {
   requestAnimationFrame(loop);


### PR DESCRIPTION
this is a complete rewrite of the bezier-easing API so it is more written in JavaScript-y style using prototype.

This was also an opportunity to optimize the performance of BezierEasing at **instanciation time**  because the previous function creation & mutation was costy. (computing the value also got a bit improved in performance but not that much – I guess because removing some scope levels).

instead of having: `BezierEasing(0, 0, 1, 1)(0.5)` you now have `BezierEasing(0, 0, 1, 1).get(0.5)`

the first method call instanciates a BezierEasing. You have a `get` method on it, but also other utility methods (toString, toCSS, getPoints).

`BezierEasing([0, 0, 1, 1])` is also now allowed.