### PR TITLE
Simplify math in algebraic solver

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const x2t = (x, a, b, c, d) => {
     const root = sqrt(s);
     return cbrt(q + root) + cbrt(q - root) - d;
   }
-  const l = cbrt(sqrt(q * q - s));
+  const l = cbrt(sqrt(-c));
   const angle = q ? Math.atan(sqrt(-s) / q) : -π / 2;
   let φ;
   if (b < 0) {


### PR DESCRIPTION
I was reading over the implementation of the recent algebraic solver when I spotted what looks like a fairly simple bit of math simplification.

On [this line](https://github.com/gre/bezier-easing/blob/0b91707a26bd0d2a44b2f6cbd4bd5c2ec9aa0031/src/index.js#L25), `s` is defined as `q ** 2 + c` a few lines prior so `q * q - s` simplifies to `-c`.

This seems fairly _mathematically_ sound but apologies if there's some weirdness I'm missing, e.g. floating-point / NaN weirdness where the current implementation deliberately _avoids_ simplification.

All the tests still pass and I also tried throwing a bunch of inputs of my own to convince myself it was fine - at worst I only saw outputs differing by tiny floating-point-error differences between implementations.

According to the `benchmark` script this improves `call` performance by ~2x (20 million / sec -> ~40 million on my machine), seemingly because `c` is constant per curve and V8 can do some clever caching for the value of `l`.

(I suspect there could be even further simplification since `c` itself comes from `w1 * w1 * w1` so it should be possible to skip a `cbrt`, but I figure this is already enough words for a five-character diff!)